### PR TITLE
Fix daily digest by adding isset check for notification metadata

### DIFF
--- a/laravel/app/Console/Commands/Notifications/Send.php
+++ b/laravel/app/Console/Commands/Notifications/Send.php
@@ -55,7 +55,7 @@ class Send extends Command
         foreach($users as $user_id)
         {
             $user = User::find($user_id);
-            
+
             // Get all notifications for this user
             $notifications = Notification::where('user_to', $user_id)->where('type', 'email')->where('status', 'new')->get();
             $this->dispatchToHandler($user, $notifications);
@@ -72,7 +72,7 @@ class Send extends Command
         {
             $metadata = json_decode($notification->metadata);
 
-            if(isset($this->eventHandler[$metadata->event]))
+            if(isset($metadata->event) && isset($this->eventHandler[$metadata->event]))
             {
                 $handler = $this->eventHandler[$metadata->event];
 
@@ -80,7 +80,7 @@ class Send extends Command
                 {
                     $queue[$handler] = [];
                 }
-                
+
                 $queue[$handler][] = $notification;
             }
         }


### PR DESCRIPTION
Really simple check, fixes bug caused by new user registration and password reset emails.

![Screenshot from 2023-02-09 00-22-35](https://user-images.githubusercontent.com/1670549/217749374-0932e6cc-6597-4814-9c44-261e45281ea1.png)

![Screenshot from 2023-02-09 00-29-47](https://user-images.githubusercontent.com/1670549/217749387-6669e48e-e2a3-4d31-82ad-73b881814ba7.png)
