### PR TITLE
Add criteria to round copy option

### DIFF
--- a/laravel/app/Http/Controllers/RoundController.php
+++ b/laravel/app/Http/Controllers/RoundController.php
@@ -31,16 +31,28 @@ class RoundController extends Controller
         $input['max_request_amount'] = Helper::filterFloat($input['max_request_amount']);
         $round = Round::create($input);
 
-        if(is_numeric($input['copy_questions'])) {
-            $oldRound = Round::find($input['copy_questions']);
+        // Should we copy data from an old grant round?
+        if(is_numeric($input['copy_data'])) {
+            // Check if the requested round actually exists
+            $oldRound = Round::find($input['copy_data']);
 
             if(!empty($oldRound)) {
+                // Loop through old questions and copy into the new round
                 foreach($oldRound->questions as $oldQuestion) {
                     $newQuestion = $oldQuestion->replicate()->fill([
                         'round_id' => $round->id
                     ]);
 
                     $newQuestion->save();
+                }
+
+                // Loop through old criteria and copy into the new round
+                foreach($oldRound->criteria as $oldCriteria) {
+                    $newCriteria = $oldCriteria->replicate()->fill([
+                        'round_id' => $round->id
+                    ]);
+
+                    $newCriteria->save();
                 }
             }
         }

--- a/laravel/resources/views/pages/round/create.blade.php
+++ b/laravel/resources/views/pages/round/create.blade.php
@@ -23,7 +23,7 @@
 
         <?php
 
-        $previousRounds = ['' => "Don't copy any questions"];
+        $previousRounds = ['' => "Don't copy any data"];
 
         foreach($rounds as $round) {
             $previousRounds[$round->id] = $round->name;
@@ -33,8 +33,9 @@
 
         @include('partials/form/select',
         [
-            'name' => 'copy_questions',
-            'label' => 'Copy Questions from an Existing Grant Round?',
+            'name' => 'copy_data',
+            'label' => 'Copy Data from an Existing Grant Round?',
+            'help' => 'This will copy all Questions and Critera from the previous round into the new round.',
             'options' => $previousRounds,
         ])
 


### PR DESCRIPTION
This PR updates the admin UI when creating new grant rounds. The existing copy question feature was expanded to also include judge criteria.

![image](https://github.com/playasoft/grants/assets/1670549/e1067088-5bed-41a1-acbc-82e1706c215b)
