### PR TITLE
Create approved budget column

### DIFF
--- a/laravel/app/Http/Controllers/ApplicationController.php
+++ b/laravel/app/Http/Controllers/ApplicationController.php
@@ -394,8 +394,12 @@ class ApplicationController extends Controller
         // Check if current user has permission
         $this->authorize('approve-application');
 
+        $input = $request->all();
+        $approved_budget = Helper::filterFloat($input['approved_budget']);
+
         $application->status = 'accepted';
         $application->judge_status = 'finalized';
+        $application->approved_budget = $approved_budget;
         $application->save();
 
         // Send notification to judges and applicant

--- a/laravel/app/Http/Controllers/ApplicationController.php
+++ b/laravel/app/Http/Controllers/ApplicationController.php
@@ -71,14 +71,14 @@ class ApplicationController extends Controller
 
         // Get user input
         $input = $request->all();
-        $input['budget'] = Helper::filterFloat($input['budget']);
+        $input['requested_budget'] = Helper::filterFloat($input['requested_budget']);
 
         // Validate requested budget against the current round settings
         if($round->min_request_amount || $round->max_request_amount)
         {
             $validator = Validator::make($input,
             [
-                'budget' => "numeric|min:{$round->min_request_amount}|max:{$round->max_request_amount}"
+                'requested_budget' => "numeric|min:{$round->min_request_amount}|max:{$round->max_request_amount}"
             ]);
 
             if($validator->fails())
@@ -170,14 +170,14 @@ class ApplicationController extends Controller
 
         // Get user input
         $input = $request->all();
-        $input['budget'] = Helper::filterFloat($input['budget']);
+        $input['requested_budget'] = Helper::filterFloat($input['requested_budget']);
 
         // Validate requested budget against the current round settings
         if($current->min_request_amount || $current->max_request_amount)
         {
             $validator = Validator::make($input,
             [
-                'budget' => "numeric|min:{$current->min_request_amount}|max:{$current->max_request_amount}"
+                'requested_budget' => "numeric|min:{$current->min_request_amount}|max:{$current->max_request_amount}"
             ]);
 
             if($validator->fails())

--- a/laravel/app/Http/Controllers/ReportsController.php
+++ b/laravel/app/Http/Controllers/ReportsController.php
@@ -46,7 +46,8 @@ class ReportsController extends Controller
             'applicant' => 'Applicant',
             'application_link' => 'Application Link',
             'applicant_email'=>'Applicant Email',
-            'budget' => 'Budget',
+            'requested_budget' => 'Requested Budget',
+            'approved_budget' => 'Approved Budget',
         ];
 
         //create columns for exportable questions
@@ -75,7 +76,8 @@ class ReportsController extends Controller
                 'applicant' => $application->user->data()->exists() ? $application->user->data->real_name : null,
                 'application_link' => url("/applications/{$application->id}/review"),
                 'applicant_email'=> $application->user->email,
-                'budget' => $application->budget
+                'requested_budget' => $application->requested_budget,
+                'approved_budget' => $application->approved_budget,
             ];
 
             //loop through questions and get the answer for that question

--- a/laravel/app/Http/Requests/ApplicationRequest.php
+++ b/laravel/app/Http/Requests/ApplicationRequest.php
@@ -28,7 +28,7 @@ class ApplicationRequest extends Request
         [
             'name' => "required|min:3",
             'description' => "required|min:100",
-            'budget' => "required|" . Helper::$moneyFormat,
+            'requested_budget' => "required|" . Helper::$moneyFormat,
         ];
     }
 }

--- a/laravel/app/Models/Application.php
+++ b/laravel/app/Models/Application.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Application extends Model
 {
-    protected $fillable = ['name', 'description', 'budget'];
+    protected $fillable = ['name', 'description', 'requested_budget'];
 
     // Applications belong to a user
     public function user()

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use DB;
+
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\Input;
@@ -22,6 +24,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        // Tell DBAL to treat enums as strings
+        DB::connection()
+            ->getDoctrineSchemaManager()
+            ->getDatabasePlatform()
+            ->registerDoctrineTypeMapping('enum', 'string');
+
         Validator::extend('account', function($attribute, $value, $parameters)
         {
             $user = User::where('name', Input::get('name'))->orWhere('email', Input::get('name'))->first();
@@ -57,7 +65,7 @@ class AppServiceProvider extends ServiceProvider
             {
                 return true;
             }
-            
+
             return false;
         });
 

--- a/laravel/database/factories/ApplicationFactory.php
+++ b/laravel/database/factories/ApplicationFactory.php
@@ -7,7 +7,7 @@ $factory->define(Application::class, function (Faker $faker) {
     return [
         'name' => $faker->words(2, $asText=true),
         'description' => $faker->paragraph(),
-        'budget' => 30000,
+        'requested_budget' => 30000,
         'status' => 'submitted',
         'user_id' => 1,
         'round_id' => 1,

--- a/laravel/database/migrations/2024_01_09_023317_add_approved_budget_column_to_applications.php
+++ b/laravel/database/migrations/2024_01_09_023317_add_approved_budget_column_to_applications.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddApprovedBudgetColumnToApplications extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->renameColumn('budget', 'requested_budget');
+            $table->decimal('approved_budget', 8, 2);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->renameColumn('requested_budget', 'budget');
+            $table->dropColumn('approved_budget');
+        });
+    }
+}

--- a/laravel/resources/css/_review.scss
+++ b/laravel/resources/css/_review.scss
@@ -15,7 +15,7 @@
         padding: 10px;
     }
     .btn {
-        margin:10px;
+        margin:10px 0;
     }
     .feedback {
         margin: 15px;

--- a/laravel/resources/js/main.js
+++ b/laravel/resources/js/main.js
@@ -4,3 +4,4 @@ require('./alerts');
 require('./menu');
 require('./scores');
 require('./applications');
+require('./review');

--- a/laravel/resources/js/review.js
+++ b/laravel/resources/js/review.js
@@ -1,0 +1,17 @@
+var $ = require('wetfish-basic');
+
+$(document).ready(function()
+{
+    $('.application-status input').on('change', function()
+    {
+        const status = $(this).value();
+
+        if(status == 'approve') {
+            $('.denied').addClass('hidden');
+            $('.approved').removeClass('hidden');
+        } else if(status == 'deny') {
+            $('.denied').removeClass('hidden');
+            $('.approved').addClass('hidden');
+        }
+    });
+});

--- a/laravel/resources/views/pages/applications/create.blade.php
+++ b/laravel/resources/views/pages/applications/create.blade.php
@@ -46,7 +46,7 @@
     {!! Form::open(['url' => 'applications']) !!}
         @include('partials/form/text', ['name' => 'name', 'label' => 'Name of Your Project', 'placeholder' => "Blinky Sparkle Pony"])
         @include('partials/form/textarea', ['name' => 'description', 'label' => 'Basic Description', 'placeholder' => "We are creating an interactive life size anamatronic pony you can climb inside of and really learn what it's like to be equine. Also the whole thing is covered in blinky lights. You've probably never seen this many LEDs in your life!"])
-        @include('partials/form/text', ['name' => 'budget', 'label' => 'Requested funds', 'placeholder' => "$1337", 'help' => "Enter the maximum amount of funding your project needs. Don't worry if it's only a rough estimate, you can update this amount later. You'll be asked to provide an itemized list in the next step"])
+        @include('partials/form/text', ['name' => 'requested_budget', 'label' => 'Requested funds', 'placeholder' => "$1337", 'help' => "Enter the maximum amount of funding your project needs. Don't worry if it's only a rough estimate, you can update this amount later. You'll be asked to provide an itemized list in the next step"])
 
         <input type="hidden" name="round_id" value="{{ $round->id }}">
         <button type="submit" class="btn btn-primary">Continue</button>

--- a/laravel/resources/views/pages/applications/list.blade.php
+++ b/laravel/resources/views/pages/applications/list.blade.php
@@ -19,13 +19,13 @@
             <div class="scrollable hidden">
         @else
             <div class="scrollable">
-        @endif   
+        @endif
             <table class="table table-hover table-striped">
                 <thead>
                     <tr>
                         <th>Name</th>
                         <th>Applicant</th>
-                        <th>Budget</th>
+                        <th>Requested Budget</th>
                         <th>Status</th>
                         <th>Judge Status</th>
                         <th>Objective Score</th>
@@ -50,7 +50,7 @@
                                 <td>
                                     <a href="/users/{{ $application->user->id }}">{{ $application->user->name }}</a>
                                 </td>
-                                <td>${{ $application->budget }}</td>
+                                <td>${{ $application->requested_budget }}</td>
                                 <td>{{ $application->status }}</td>
                                 <td>{{ $application->judge_status }}</td>
                                 <td>{{ $application->objective_score }}</td>

--- a/laravel/resources/views/pages/applications/list.blade.php
+++ b/laravel/resources/views/pages/applications/list.blade.php
@@ -26,6 +26,7 @@
                         <th>Name</th>
                         <th>Applicant</th>
                         <th>Requested Budget</th>
+                        <th>Approved Budget</th>
                         <th>Status</th>
                         <th>Judge Status</th>
                         <th>Objective Score</th>
@@ -51,6 +52,7 @@
                                     <a href="/users/{{ $application->user->id }}">{{ $application->user->name }}</a>
                                 </td>
                                 <td>${{ $application->requested_budget }}</td>
+                                <td>${{ $application->approved_budget }}</td>
                                 <td>{{ $application->status }}</td>
                                 <td>{{ $application->judge_status }}</td>
                                 <td>{{ $application->objective_score }}</td>

--- a/laravel/resources/views/pages/applications/review.blade.php
+++ b/laravel/resources/views/pages/applications/review.blade.php
@@ -440,13 +440,31 @@
                         </b>
                     </p>
 
-                    {!! Form::open(['url' => "applications/{$application->id}/approve", 'style' => "display: inline-block"]) !!}
-                        <button type="submit" class="btn btn-success">Approve Application</button>
-                    {!! Form::close() !!}
+                    <div class="application-status">
+                        @include('partials/form/radio', [
+                            'name' => 'status',
+                            'label' => 'Application Status',
+                            'options' => [
+                                '' => 'Pending',
+                                'approve' => 'Approved',
+                                'deny' => 'Denied'
+                            ],
+                        ])
+                    </div>
 
-                    {!! Form::open(['url' => "applications/{$application->id}/deny", 'style' => "display: inline-block"]) !!}
-                        <button type="submit" class="btn btn-danger">Deny Application</button>
-                    {!! Form::close() !!}
+                    <div class="approved hidden">
+                        {!! Form::open(['url' => "applications/{$application->id}/approve", 'style' => "display: inline-block"]) !!}
+                            @include('partials/form/text', ['name' => 'approved_budget', 'label' => 'Approved Budget', 'placeholder' => "$1337"])
+
+                            <button type="submit" class="btn btn-success">Approve Application</button>
+                        {!! Form::close() !!}
+                    </div>
+
+                    <div class="denied hidden">
+                        {!! Form::open(['url' => "applications/{$application->id}/deny", 'style' => "display: inline-block"]) !!}
+                            <button type="submit" class="btn btn-danger">Deny Application</button>
+                        {!! Form::close() !!}
+                    </div>
                 @endif
             @endcan
         </div>

--- a/laravel/resources/views/pages/applications/review.blade.php
+++ b/laravel/resources/views/pages/applications/review.blade.php
@@ -109,7 +109,7 @@
             </div>
 
             <div class="title">Requested funds</div>
-            <div class="title ans">${{ $application->budget }}</div>
+            <div class="title ans">${{ $application->requested_budget }}</div>
 
             @can('create-feedback')
                 <a href="/applications/{{ $application->id }}/feedback" class="btn btn-primary">Ask General Question</a>

--- a/laravel/resources/views/pages/applications/view.blade.php
+++ b/laravel/resources/views/pages/applications/view.blade.php
@@ -36,11 +36,11 @@
 
         @include('partials/form/text',
         [
-            'name' => 'budget',
+            'name' => 'requested_budget',
             'label' => 'Requested funds',
             'placeholder' => "$1337",
             'help' => "The maximum amount your project needs",
-            'value' => '$' . $application->budget
+            'value' => '$' . $application->requested_budget
         ])
     {!! Form::close() !!}
 

--- a/laravel/resources/views/pages/dashboard.blade.php
+++ b/laravel/resources/views/pages/dashboard.blade.php
@@ -80,7 +80,7 @@ $showrounds = $ongoing->merge($upcoming);
                         @can('view-submitted-application')
                             <th>Applicant</th>
                         @endcan
-                        <th>Budget</th>
+                        <th>Requested Budget</th>
                         <th>Status</th>
                         <th>Created</th>
                         <th>Last Modified</th>
@@ -104,7 +104,7 @@ $showrounds = $ongoing->merge($upcoming);
                                 @can('view-submitted-application')
                                     <td><a href="/users/{{ $application->user->id }}">{{ $application->user->name }}</a></td>
                                 @endcan
-                                <td>${{ $application->budget }}</td>
+                                <td>${{ $application->requested_budget }}</td>
                                 <td>{{ $application->status }}</td>
                                 <td>{{ $application->created_at->format('Y-m-d H:i:s e') }}</td>
                                 <td>{{ $application->updated_at->format('Y-m-d H:i:s e') }}</td>

--- a/laravel/resources/views/partials/form/radio.blade.php
+++ b/laravel/resources/views/partials/form/radio.blade.php
@@ -1,0 +1,18 @@
+@extends('partials/form/_bootstrap')
+
+@section('html')
+    @foreach($options as $option => $text)
+        <div class="radio">
+            <label>
+                <input type="radio"
+                        name="{{ $name }}"
+                        id="{{ $name }}-field"
+                        placeholder="{{ $placeholder or '' }}"
+                        value="{{ $option }}"
+                        {{ (isset($value) && $value == $option) ? 'selected' : '' }}>
+
+                {{ $text }}
+            </label>
+        </div>
+    @endforeach
+@overwrite


### PR DESCRIPTION
This PR adds a new `approved_budget` column to the applications table and renames the old `budget` column to be called `requested_budget` instead. 

When admins approve an application they can now specify the amount the application is being approved for which will later be used by the automated document signing logic. 

![Screenshot from 2024-01-09 18-59-14](https://github.com/playasoft/grants/assets/1670549/e38032dc-c792-4fbc-aba5-fbd4b9981e26)
![Screenshot from 2024-01-09 18-59-22](https://github.com/playasoft/grants/assets/1670549/7f0f8f95-741b-4612-bdaf-b809ab5d13a9)